### PR TITLE
a11y improvements

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -56,8 +56,7 @@
         {% block bodyNavigation %}
             <nav class="container-fluid">
                 <ul>
-                    <li><a href="{{ route() }}"><span class="fa fa-joomla" aria-hidden=
-                    "true"></span><span class="title">Framework</span></a></li>
+                    <li><a href="{{ route() }}"><span class="fa fa-joomla" aria-hidden="true"></span><span class="title">Framework</span></a></li>
                     <li><a href="{{ route('contributors') }}"><span class="fa fa-user" aria-hidden="true"></span><span class="title">Team</span></a></li>
                     <li><a href="{{ route('status') }}"><span class="fa fa-wrench" aria-hidden="true"></span><span class="title">Status</span></a></li>
                 </ul>

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -56,9 +56,10 @@
         {% block bodyNavigation %}
             <nav class="container-fluid">
                 <ul>
-                    <li><a href="{{ route() }}"><span class="fa fa-joomla"></span><span class="title">Framework</span></a></li>
-                    <li><a href="{{ route('contributors') }}"><span class="fa fa-user"></span><span class="title">Team</span></a></li>
-                    <li><a href="{{ route('status') }}"><span class="fa fa-wrench"></span><span class="title">Status</span></a></li>
+                    <li><a href="{{ route() }}"><span class="fa fa-joomla" aria-hidden=
+                    "true"></span><span class="title">Framework</span></a></li>
+                    <li><a href="{{ route('contributors') }}"><span class="fa fa-user" aria-hidden="true"></span><span class="title">Team</span></a></li>
+                    <li><a href="{{ route('status') }}"><span class="fa fa-wrench" aria-hidden="true"></span><span class="title">Status</span></a></li>
                 </ul>
             </nav>
         {% endblock %}

--- a/templates/package.twig
+++ b/templates/package.twig
@@ -6,7 +6,7 @@
 
 {% block content %}
 <section class="status container">
-    <h1 class="centered-title">Release Data for {{ package.display }} Package <a href="https://github.com/joomla-framework/{{ package.repo }}"><span class="fa fa-github"></span></a></h1>
+    <h1 class="centered-title">Release Data for {{ package.display }} Package <a href="https://github.com/joomla-framework/{{ package.repo }}"><span class="fa fa-github" aria-hidden="true"></span><span class="sr-only">Open {{ package.display }} on GitHub</span></a></h1>
     {% if package.abandoned %}
         <div class="alert alert-danger">
             <h4>Abandoned Package</h4>

--- a/templates/status.twig
+++ b/templates/status.twig
@@ -23,7 +23,7 @@
             {% for release in releases %}
                 <tr>
                     <th scope="row" data-label="Package">
-                        <a href="https://github.com/joomla-framework/{{ release.package.repo }}"><span class="fa fa-github"></span></a> <a href="{{ route('status/' ~ release.package.package) }}">{{ release.package.display }}</a>
+                        <a href="https://github.com/joomla-framework/{{ release.package.repo }}"><span class="fa fa-github" aria-hidden="true"></span><span class="sr-only">Open {{ release.package.display }} on GitHub</span></a> <a href="{{ route('status/' ~ release.package.package) }}">{{ release.package.display }}</a>
                         {% if release.package.deprecated %}
                             <br><span class="badge badge-warning">Deprecated</span>
                         {% endif %}


### PR DESCRIPTION
Mainly making sure that fa icons are hidden from screenreaders AND that the links to github have meaningful text

In addition the color for the a tag fails a contrast check and should be changed from #428bca to #214a73