### PR TITLE
Switching from Travis badges to Drone badges for status

### DIFF
--- a/templates/status.twig
+++ b/templates/status.twig
@@ -39,7 +39,7 @@
                             N/A
                         {% else %}
                             {% set _1xbranch = release.package.repo in ['crypt'] ? '1.x-dev' : 'master'  %}
-                            <a href="https://travis-ci.org/joomla-framework/{{ release.package.repo }}"><img src="https://travis-ci.org/joomla-framework/{{ release.package.repo }}.png?branch={{ _1xbranch }}" alt="Build Status" /></a>
+                            <a href="https://ci.joomla.org/joomla-framework/{{ release.package.repo }}"><img src="https://ci.joomla.org/api/badges/joomla-framework/{{ release.package.repo }}/status.svg?ref=refs/heads/{{ _1xbranch }}" alt="Build Status" /></a>
                         {% endif %}
                     </td>
                     <td data-label="2.0 Build Status">
@@ -47,7 +47,7 @@
                             N/A
                         {% else %}
                             {% set _2xbranch = release.package.repo in ['crypt', 'renderer', 'symfony-event-dispatcher-bridge'] ? 'master' : '2.0-dev'  %}
-                            <a href="https://travis-ci.org/joomla-framework/{{ release.package.repo }}"><img src="https://travis-ci.org/joomla-framework/{{ release.package.repo }}.png?branch={{ _2xbranch }}" alt="Build Status" /></a>
+                            <a href="https://ci.joomla.org/joomla-framework/{{ release.package.repo }}"><img src="https://ci.joomla.org/api/badges/joomla-framework/{{ release.package.repo }}/status.svg?ref=refs/heads/{{ _2xbranch }}" alt="Build Status" /></a>
                         {% endif %}
                     </td>
                 </tr>


### PR DESCRIPTION
Since we are switching over the framework packages from the Travis CI to Drone, we should also switch over the status badges on the status page from Travis to Drone. This PR does that. Note that as of creating this PR, only a few framework packages have been converted to Drone. Merging should be delayed until a reasonable amount of packages have been converted.