### PR TITLE
Removing double basepath from media path

### DIFF
--- a/src/WebApplication.php
+++ b/src/WebApplication.php
@@ -63,6 +63,16 @@ class WebApplication extends AbstractWebApplication
 
 		// Call the constructor as late as possible (it runs `initialise`).
 		parent::__construct($input, $config, $client, $response);
+
+		// If an explicitly media URI is set, don't do anything.
+		$mediaURI = trim($this->get('media_uri'));
+
+		if (!$mediaURI)
+		{
+			// No explicit media URI was set, build it dynamically from the base uri.
+			$this->set('uri.media.full', 'media/');
+			$this->set('uri.media.path', 'media/');
+		}
 	}
 
 	/**


### PR DESCRIPTION
This fixes #57. 

~~I've gone through a lot of code and I'm still not sure about this. It looks like a general bug in the AbstractApplication class and this fix feels like pretty wrong, but it works... Please give this a thorough review...~~

I've debugged this further and the change I did seems to be the correct fix for this.