### PR TITLE
Removing Google Tag Manager

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -48,10 +48,6 @@
        	</script>
     </head>
     <body id="go">
-        <!-- Google Tag Manager -->
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NX46ZP" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-NX46ZP');</script>
-        <!-- End Google Tag Manager -->
         {% block bodyNavigation %}
             <nav class="container-fluid">
                 <ul>


### PR DESCRIPTION
Based on this issue https://github.com/joomla/joomla-websites/issues/1348, I'm removing the Google Tag Manager from the framework site. GDPR requires us to either request consent before including this stuff or not include it at all. Since we couldn't get our shit together for over 2 years now, I'm starting this second attempt at removing this. AFAIK we aren't even using the data we collect here. Use a better, more privacy-friendly solution if you really think you need it.