### PR TITLE
Updating Twig to 3.4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/web-link": "^5.1.2",
         "symfony/yaml": "^5.1.2",
         "theiconic/php-ga-measurement-protocol": "^2.7.2",
-        "twig/twig": "^2.13"
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13e6edc87f3b3b24d2f54df450d5a401",
+    "content-hash": "01c4bdc1b46900a7e1f4f5b7d3c01d96",
     "packages": [
         {
             "name": "brick/math",
@@ -4459,23 +4459,22 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.15.2",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3e43405a9a8b578809426339cc3780e16fba0c52"
+                "reference": "e07cdd3d430cd7e453c31b36eb5ad6c0c5e43077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3e43405a9a8b578809426339cc3780e16fba0c52",
-                "reference": "3e43405a9a8b578809426339cc3780e16fba0c52",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e07cdd3d430cd7e453c31b36eb5ad6c0c5e43077",
+                "reference": "e07cdd3d430cd7e453c31b36eb5ad6c0c5e43077",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php72": "^1.8"
+                "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
@@ -4484,13 +4483,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.15-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -4523,7 +4519,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.15.2"
+                "source": "https://github.com/twigphp/Twig/tree/v3.4.2"
             },
             "funding": [
                 {
@@ -4535,7 +4531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-12T06:43:37+00:00"
+            "time": "2022-08-12T06:47:24+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Service/DebugBarProvider.php
+++ b/src/Service/DebugBarProvider.php
@@ -10,8 +10,7 @@
 namespace Joomla\FrameworkWebsite\Service;
 
 use DebugBar\Bridge\MonologCollector;
-use DebugBar\Bridge\Twig\TimeableTwigExtensionProfiler;
-use DebugBar\Bridge\TwigProfileCollector;
+use DebugBar\Bridge\NamespacedTwigProfileCollector;
 use DebugBar\DataCollector\PDO\PDOCollector;
 use DebugBar\DataCollector\PDO\TraceablePDO;
 use DebugBar\DebugBar;
@@ -33,6 +32,7 @@ use Joomla\FrameworkWebsite\Router\DebugRouter;
 use Joomla\Input\Input;
 use Joomla\Router\RouterInterface;
 use Psr\Log\LoggerInterface;
+use Twig\Extension\ProfilerExtension;
 
 /**
  * Debug bar service provider
@@ -137,9 +137,9 @@ class DebugBarProvider implements ServiceProviderInterface
      *
      * @return  TwigProfileCollector
      */
-    public function getDebugCollectorTwigService(Container $container): TwigProfileCollector
+    public function getDebugCollectorTwigService(Container $container): NamespacedTwigProfileCollector
     {
-        return new TwigProfileCollector($container->get('twig.profiler.profile'), $container->get('twig.loader'));
+        return new NamespacedTwigProfileCollector($container->get('twig.profiler.profile'));
     }
 
     /**
@@ -203,19 +203,16 @@ class DebugBarProvider implements ServiceProviderInterface
     /**
      * Get the decorated `twig.extension.profiler` service
      *
-     * @param   \Twig_Extension_Profiler  $profiler   The original \Twig_Extension_Profiler service.
-     * @param   Container                 $container  The DI container.
+     * @param   ProfilerExtension  $profiler   The original ProfilerExtension service.
+     * @param   Container          $container  The DI container.
      *
-     * @return  TimeableTwigExtensionProfiler
+     * @return  NamespacedTwigProfileCollector
      */
     public function getDecoratedTwigExtensionProfilerService(
-        \Twig_Extension_Profiler $profiler,
+        ProfilerExtension $profiler,
         Container $container
-    ): TimeableTwigExtensionProfiler {
-        return new TimeableTwigExtensionProfiler(
-            $container->get('twig.profiler.profile'),
-            $container->get('debug.bar')['time']
-        );
+    ): ProfilerExtension {
+        return new ProfilerExtension($container->get('twig.profiler.profile'));
     }
 
     /**

--- a/src/Service/TemplatingProvider.php
+++ b/src/Service/TemplatingProvider.php
@@ -54,30 +54,23 @@ class TemplatingProvider implements ServiceProviderInterface
             ->alias(TwigRenderer::class, 'renderer')
             ->share('renderer', [$this, 'getRendererService'], true);
         $container->alias(CacheInterface::class, 'twig.cache')
-            ->alias(\Twig_CacheInterface::class, 'twig.cache')
             ->share('twig.cache', [$this, 'getTwigCacheService'], true);
         $container->alias(Environment::class, 'twig.environment')
-            ->alias(\Twig_Environment::class, 'twig.environment')
             ->share('twig.environment', [$this, 'getTwigEnvironmentService'], true);
         $container->alias(DebugExtension::class, 'twig.extension.debug')
-            ->alias(\Twig_Extension_Debug::class, 'twig.extension.debug')
             ->share('twig.extension.debug', [$this, 'getTwigExtensionDebugService'], true);
         $container->alias(FrameworkExtension::class, 'twig.extension.framework')
             ->share('twig.extension.framework', [$this, 'getTwigExtensionFrameworkService'], true);
 // This service cannot be protected as it is decorated when the debug bar is available
         $container->alias(ProfilerExtension::class, 'twig.extension.profiler')
-            ->alias(\Twig_Extension_Profiler::class, 'twig.extension.profiler')
             ->share('twig.extension.profiler', [$this, 'getTwigExtensionProfilerService']);
         $container->alias(LoaderInterface::class, 'twig.loader')
-            ->alias(\Twig_LoaderInterface::class, 'twig.loader')
             ->share('twig.loader', [$this, 'getTwigLoaderService'], true);
         $container->alias(Profile::class, 'twig.profiler.profile')
-            ->alias(\Twig_Profiler_Profile::class, 'twig.profiler.profile')
             ->share('twig.profiler.profile', [$this, 'getTwigProfilerProfileService'], true);
         $container->alias(FrameworkTwigRuntime::class, 'twig.runtime.framework')
             ->share('twig.runtime.framework', [$this, 'getTwigRuntimeFrameworkService'], true);
         $container->alias(ContainerRuntimeLoader::class, 'twig.runtime.loader')
-            ->alias(\Twig_ContainerRuntimeLoader::class, 'twig.runtime.loader')
             ->share('twig.runtime.loader', [$this, 'getTwigRuntimeLoaderService'], true);
         $this->tagTwigExtensions($container);
     }
@@ -119,9 +112,9 @@ class TemplatingProvider implements ServiceProviderInterface
      *
      * @param   Container  $container  The DI container.
      *
-     * @return  \Twig_CacheInterface
+     * @return  CacheInterface
      */
-    public function getTwigCacheService(Container $container): \Twig_CacheInterface
+    public function getTwigCacheService(Container $container): CacheInterface
     {
         /** @var \Joomla\Registry\Registry $config */
         $config = $container->get('config');
@@ -202,9 +195,9 @@ class TemplatingProvider implements ServiceProviderInterface
      *
      * @param   Container  $container  The DI container.
      *
-     * @return  \Twig_LoaderInterface
+     * @return  LoaderInterface
      */
-    public function getTwigLoaderService(Container $container): \Twig_LoaderInterface
+    public function getTwigLoaderService(Container $container): LoaderInterface
     {
         return new FilesystemLoader([JPATH_TEMPLATES]);
     }


### PR DESCRIPTION
@nibra @HLeithner could you two check if this is okay? I'm updating this, since the error messages from twig aren't really saying much and we have sometimes 20k lines of empty errors in our drone output: https://ci.joomla.org/joomla/framework.joomla.org/116/1/8
Could it be that the webserver has permissions to write to the cache folder (or rather delete its content), while the CLI user doesn't?

Anyway, I'm hoping that the update to Twig 3 would give us better error output. Here is some documentation I used to migrate from v2 to v3: 
- https://symfony.com/blog/preparing-your-applications-for-twig-3
- https://github.com/maximebf/php-debugbar/blob/master/docs/bridge_collectors.md

Please merge if you are happy with this.